### PR TITLE
[526] Stereotype applications shouldn't be visible in the model explorer

### DIFF
--- a/plugins/org.obeonetwork.dsl.uml2.navigator/plugin.xml
+++ b/plugins/org.obeonetwork.dsl.uml2.navigator/plugin.xml
@@ -12,6 +12,14 @@
            </instanceof>
         </enablement>
      </actionProvider>
+     <commonFilter
+           activeByDefault="true"
+           class="org.obeonetwork.dsl.uml2.editor.internal.UMLStereotypeApplicationFilter"
+           description="Hides Stereotype applications"
+           id="org.obeonetwork.dsl.uml2.navigator.commonFilter.stereotypeapplication"
+           name="UML Stereotype applications"
+           visibleInUI="true">
+     </commonFilter>
   </extension>
   <extension
         point="org.eclipse.ui.navigator.viewer">
@@ -28,6 +36,9 @@
         <includes>
            <contentExtension
                  pattern="org.obeonetwork.dsl.uml2.editor.*">
+           </contentExtension>
+           <contentExtension
+                 pattern="org.obeonetwork.dsl.uml2.navigator.commonFilter.*">
            </contentExtension>
         </includes>
      </viewerContentBinding>

--- a/plugins/org.obeonetwork.dsl.uml2.navigator/src/org/obeonetwork/dsl/uml2/editor/internal/UMLStereotypeApplicationFilter.java
+++ b/plugins/org.obeonetwork.dsl.uml2.navigator/src/org/obeonetwork/dsl/uml2/editor/internal/UMLStereotypeApplicationFilter.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.obeonetwork.dsl.uml2.editor.internal;
+
+import java.util.List;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerFilter;
+
+/**
+ * Filter to enable the user to hide Stereotype applications displayed as
+ * children of UML resources.
+ * 
+ * @author <a href="mailto:cedric.notot@obeo.fr">Cédric Notot</a>
+ * 
+ */
+public class UMLStereotypeApplicationFilter extends ViewerFilter {
+
+	public UMLStereotypeApplicationFilter() {
+		// TODO Auto-generated constructor stub
+	}
+
+	@Override
+	public boolean select(Viewer viewer, Object parentElement, Object element) {
+		return !(element instanceof EObject 
+				&& ((EObject)element).eContainer() == null
+				&& containsBaseReference(((EObject)element).eClass().getEAllReferences()));
+	}
+	
+	private boolean containsBaseReference(List<EReference> references) {
+		for (EReference eReference : references) {
+			if (eReference.getName().startsWith("base_")) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}


### PR DESCRIPTION
As now, the stereotype applications are hidden. It is possible to see
them again using the "Customize View.../Filters" action of the standard
Eclipse View Menu and unchecking the "UML Stereotype applications"
option.