### PR TITLE
Fix #591 reconnect generalization in use case diag

### DIFF
--- a/plugins/org.obeonetwork.dsl.uml2.design/description/uml2.odesign
+++ b/plugins/org.obeonetwork.dsl.uml2.design/description/uml2.odesign
@@ -1026,7 +1026,7 @@
               </firstModelOperations>
             </initialOperation>
           </ownedTools>
-          <ownedTools xsi:type="tool_1:EdgeCreationDescription" documentation="Tool to create a Generalization" name="Generalization" precondition="[preSource->including(preTarget)->filter(uml::Actor)->size() = 2 or preSource->including(preTarget)->filter(uml::UseCase)->size() = 2/]" edgeMappings="//@ownedViewpoints[name='Capture']/@ownedRepresentations[name='Use%20Case%20Diagram']/@defaultLayer/@edgeMappings[name='UCD_Generalization']">
+          <ownedTools xsi:type="tool_1:EdgeCreationDescription" documentation="Tool to create a Generalization" name="Generalization" precondition="service:preSource.isSameType(preTarget)" edgeMappings="//@ownedViewpoints[name='Capture']/@ownedRepresentations[name='Use%20Case%20Diagram']/@defaultLayer/@edgeMappings[name='UCD_Generalization']">
             <sourceVariable name="source"/>
             <targetVariable name="target"/>
             <sourceViewVariable name="sourceView"/>
@@ -1136,7 +1136,7 @@
               </initialOperation>
               <edgeView name="edgeView"/>
             </ownedTools>
-            <ownedTools xsi:type="tool_1:ReconnectEdgeDescription" name="UCD_ReconnectGeneralizationSource" reconnectionKind="RECONNECT_SOURCE">
+            <ownedTools xsi:type="tool_1:ReconnectEdgeDescription" name="UCD_ReconnectGeneralizationSource" precondition="service:source.isSameType(target)" reconnectionKind="RECONNECT_SOURCE">
               <source name="source"/>
               <target name="target"/>
               <sourceView name="sourceView"/>
@@ -1149,7 +1149,7 @@
               </initialOperation>
               <edgeView name="edgeView"/>
             </ownedTools>
-            <ownedTools xsi:type="tool_1:ReconnectEdgeDescription" name="UCD_ReconnectGeneralizationTarget">
+            <ownedTools xsi:type="tool_1:ReconnectEdgeDescription" name="UCD_ReconnectGeneralizationTarget" precondition="service:source.isSameType(target)">
               <source name="source"/>
               <target name="target"/>
               <sourceView name="sourceView"/>

--- a/plugins/org.obeonetwork.dsl.uml2.design/src/org/obeonetwork/dsl/uml2/design/api/services/AbstractDiagramServices.java
+++ b/plugins/org.obeonetwork.dsl.uml2.design/src/org/obeonetwork/dsl/uml2/design/api/services/AbstractDiagramServices.java
@@ -705,6 +705,19 @@ public abstract class AbstractDiagramServices {
 	}
 
 	/**
+	 * Compare two Objects types.
+	 *
+	 * @param source
+	 *            EObject
+	 * @param target
+	 *            EObject
+	 * @return true if objects have the same type (eClass)
+	 */
+	public boolean isSameType(final EObject source, final EObject target) {
+		return source.eClass().equals(target.eClass());
+	}
+
+	/**
 	 * Check if a semantic element can be represented in a given container view.
 	 *
 	 * @param container


### PR DESCRIPTION
Add a new service in abstract diagram to compare type fo source and
target. Add this service a precondition in generalization creation tool
and in reconnection tools.