### PR TITLE
Fix selection window name was changed

### DIFF
--- a/tests/org.obeonetwork.dsl.uml2.tests.rcptt/PackageHierarchyDiagram/AddExistingElementWithPaletteToolInPackageHierarchyDiagram2.test
+++ b/tests/org.obeonetwork.dsl.uml2.tests.rcptt/PackageHierarchyDiagram/AddExistingElementWithPaletteToolInPackageHierarchyDiagram2.test
@@ -7,7 +7,7 @@ Element-Version: 3.0
 External-Reference: 
 Id: _2BohAN97EeSEJ-mMQXHd1A
 Runtime-Version: 1.5.5.201503020312
-Save-Time: 4/10/15 3:02 PM
+Save-Time: 5/28/15 9:50 AM
 Testcase-Type: ecl
 
 ------=_.description-216f885c-d591-38ce-8ea2-e4f8cb4d6ffa
@@ -42,9 +42,9 @@ with [get-editor "Test Travel Agency Package Hierarchy"] {
         mouse-release 70 89 button1 524288 -height 524 -width 793
     }
 }
-with [get-window "Select element to add in current representation"] {
+with [get-window "Add existing elements"] {
     get-tree | select "<Model> Travel Agency/<Package> Components"
-    get-button Finish | click
+    get-button OK | click
 }
 // Add a second existing element which is connected to ellement already displayed
 with [get-editor "Test Travel Agency Package Hierarchy"] {
@@ -60,9 +60,9 @@ with [get-editor "Test Travel Agency Package Hierarchy"] {
     }
 }
 // Check packages are displayed and connection is visible in diagram
-with [get-window "Select element to add in current representation"] {
+with [get-window "Add existing elements"] {
     get-tree | select "<Model> Travel Agency/<Package> Interfaces" | double-click
-    get-button Finish | click
+    get-button OK | click
 }
 with [get-editor "Test Travel Agency Package Hierarchy" | get-diagram -index 1 | get-edit-part 
     -name "Test Travel Agency Package Hierarchy"] {


### PR DESCRIPTION
- AddExistingElementWithPaletteToolInPackageHierarchyDiagram
the window "Select element to add in current representation" is named
"Addexisting elements"