### PR TITLE
Fix CS diag Add branch or element, drop from model

### DIFF
--- a/plugins/org.obeonetwork.dsl.uml2.design/src/org/obeonetwork/dsl/uml2/design/api/services/AbstractDiagramServices.java
+++ b/plugins/org.obeonetwork.dsl.uml2.design/src/org/obeonetwork/dsl/uml2/design/api/services/AbstractDiagramServices.java
@@ -334,7 +334,9 @@ public abstract class AbstractDiagramServices {
 	 */
 	public void dropFromModel(final Element newContainer, final Element semanticElement,
 			final DSemanticDecorator containerView) {
-		drop(newContainer, semanticElement, containerView, !(containerView instanceof DSemanticDiagram));
+		final Session session = SessionManager.INSTANCE.getSession(semanticElement);
+		markForAutosize(semanticElement);
+		showView(semanticElement, containerView, session, "[self.getContainerView(newContainerView)/]"); //$NON-NLS-1$
 	}
 
 	/**


### PR DESCRIPTION
Fix add exisiting element:
if an element is selected an is father is not visible, the element is add
to the diagram intead of the element where the tool was applied.
It was not possible to add an element elsewere of his father.

Two services are created:
- to add directly in the selected element
- to add an element from selected branch
If a branch is selected all elements are added with same hierarchy.

Fix drop from model:
when an element is drop from model it is only add to diagram but the
element is no more moved in model.