### PR TITLE
Integration request771

### DIFF
--- a/plugins/org.obeonetwork.dsl.uml2.design/description/uml2.odesign
+++ b/plugins/org.obeonetwork.dsl.uml2.design/description/uml2.odesign
@@ -2582,32 +2582,32 @@
           <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="service:targetIsNavigable">
             <featureCustomizations xsi:type="description:EAttributeCustomization" appliedOn="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@edgeMappings[name='CD_Association']/@style" attributeName="targetArrow" value="aql:diagram::EdgeArrows::InputArrow"/>
           </vsmElementCustomizations>
-          <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="service:targetIsComposite">
-            <featureCustomizations xsi:type="description:EAttributeCustomization" appliedOn="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@edgeMappings[name='CD_Association']/@style" attributeName="targetArrow" value="aql:diagram::EdgeArrows::FillDiamond"/>
-          </vsmElementCustomizations>
-          <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="service:targetIsShared">
+          <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="service:sourceIsShared">
             <featureCustomizations xsi:type="description:EAttributeCustomization" appliedOn="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@edgeMappings[name='CD_Association']/@style" attributeName="targetArrow" value="aql:diagram::EdgeArrows::Diamond"/>
           </vsmElementCustomizations>
-          <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="service:targetIsNavigableAndComposite">
-            <featureCustomizations xsi:type="description:EAttributeCustomization" appliedOn="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@edgeMappings[name='CD_Association']/@style" attributeName="targetArrow" value="aql:diagram::EdgeArrows::InputArrowWithFillDiamond"/>
+          <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="service:sourceIsComposite">
+            <featureCustomizations xsi:type="description:EAttributeCustomization" appliedOn="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@edgeMappings[name='CD_Association']/@style" attributeName="targetArrow" value="aql:diagram::EdgeArrows::FillDiamond"/>
           </vsmElementCustomizations>
-          <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="service:targetIsNavigableAndShared">
+          <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="service:targetIsNavigableAndSourceIsShared">
             <featureCustomizations xsi:type="description:EAttributeCustomization" appliedOn="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@edgeMappings[name='CD_Association']/@style" attributeName="targetArrow" value="aql:diagram::EdgeArrows::InputArrowWithDiamond"/>
+          </vsmElementCustomizations>
+          <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="service:targetIsNavigableAndSourceIsComposite">
+            <featureCustomizations xsi:type="description:EAttributeCustomization" appliedOn="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@edgeMappings[name='CD_Association']/@style" attributeName="targetArrow" value="aql:diagram::EdgeArrows::InputArrowWithFillDiamond"/>
           </vsmElementCustomizations>
           <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="service:sourceIsNavigable">
             <featureCustomizations xsi:type="description:EAttributeCustomization" appliedOn="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@edgeMappings[name='CD_Association']/@style" attributeName="sourceArrow" value="aql:diagram::EdgeArrows::InputArrow"/>
           </vsmElementCustomizations>
-          <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="service:sourceIsComposite">
-            <featureCustomizations xsi:type="description:EAttributeCustomization" appliedOn="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@edgeMappings[name='CD_Association']/@style" attributeName="sourceArrow" value="aql:diagram::EdgeArrows::FillDiamond"/>
-          </vsmElementCustomizations>
-          <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="service:sourceIsShared">
+          <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="service:targetIsShared">
             <featureCustomizations xsi:type="description:EAttributeCustomization" appliedOn="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@edgeMappings[name='CD_Association']/@style" attributeName="sourceArrow" value="aql:diagram::EdgeArrows::Diamond"/>
           </vsmElementCustomizations>
-          <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="service:sourceIsNavigableAndComposite">
-            <featureCustomizations xsi:type="description:EAttributeCustomization" appliedOn="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@edgeMappings[name='CD_Association']/@style" attributeName="sourceArrow" value="aql:diagram::EdgeArrows::InputArrowWithFillDiamond"/>
+          <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="service:targetIsComposite">
+            <featureCustomizations xsi:type="description:EAttributeCustomization" appliedOn="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@edgeMappings[name='CD_Association']/@style" attributeName="sourceArrow" value="aql:diagram::EdgeArrows::FillDiamond"/>
           </vsmElementCustomizations>
-          <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="service:sourceIsNavigableAndShared">
+          <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="service:sourceIsNavigableAndTargetIsShared">
             <featureCustomizations xsi:type="description:EAttributeCustomization" appliedOn="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@edgeMappings[name='CD_Association']/@style" attributeName="sourceArrow" value="aql:diagram::EdgeArrows::InputArrowWithDiamond"/>
+          </vsmElementCustomizations>
+          <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="service:sourceIsNavigableAndTargetIsComposite">
+            <featureCustomizations xsi:type="description:EAttributeCustomization" appliedOn="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@edgeMappings[name='CD_Association']/@style" attributeName="sourceArrow" value="aql:diagram::EdgeArrows::InputArrowWithFillDiamond"/>
           </vsmElementCustomizations>
           <vsmElementCustomizations xsi:type="description:VSMElementCustomization" predicateExpression="feature:isAbstract">
             <featureCustomizations xsi:type="description:EAttributeCustomization" appliedOn="//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@containerMappings[name='CD_Class']/@style //@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@containerMappings[name='CD_DataType']/@style //@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@containerMappings[name='CD_Class']/@conditionnalStyles.0/@style //@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@containerMappings[name='CD_DataType']/@conditionnalStyles.0/@style //@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@containerMappings[name='CD_Enumeration']/@style //@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@containerMappings[name='CD_PrimitiveType']/@style //@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@containerMappings[name='CD_Enumeration']/@conditionnalStyles.0/@style //@ownedViewpoints[name='Design']/@ownedRepresentations[name='Class%20Diagram']/@defaultLayer/@containerMappings[name='CD_PrimitiveType']/@conditionnalStyles.0/@style" attributeName="labelFormat" value="service:self.getAbstractBoldLabelFormat"/>

--- a/plugins/org.obeonetwork.dsl.uml2.design/src/org/obeonetwork/dsl/uml2/design/api/services/ClassDiagramServices.java
+++ b/plugins/org.obeonetwork.dsl.uml2.design/src/org/obeonetwork/dsl/uml2/design/api/services/ClassDiagramServices.java
@@ -559,9 +559,10 @@ public class ClassDiagramServices extends AbstractDiagramServices {
 	 *            Association
 	 * @return True if source is navigable and composite
 	 */
-	public boolean sourceIsNavigableAndComposite(Association association) {
+	public boolean sourceIsNavigableAndTargetIsComposite(Association association) {
 		final Property source = AssociationServices.INSTANCE.getSource(association);
-		return isNavigable(source) && isComposite(source);
+	final Property target = AssociationServices.INSTANCE.getTarget(association);
+	return isNavigable(source) && isComposite(target);
 	}
 
 	/**
@@ -571,9 +572,10 @@ public class ClassDiagramServices extends AbstractDiagramServices {
 	 *            Association
 	 * @return True if source is navigable and shared
 	 */
-	public boolean sourceIsNavigableAndShared(Association association) {
-		final Property source = AssociationServices.INSTANCE.getTarget(association);
-		return isNavigable(source) && isShared(source);
+	public boolean sourceIsNavigableAndTargetIsShared(Association association) {
+	final Property source = AssociationServices.INSTANCE.getSource(association);
+	final Property target = AssociationServices.INSTANCE.getTarget(association);
+	return isNavigable(source) && isShared(target);
 	}
 
 	/**
@@ -619,9 +621,10 @@ public class ClassDiagramServices extends AbstractDiagramServices {
 	 *            Association
 	 * @return True if target is navigable and composite
 	 */
-	public boolean targetIsNavigableAndComposite(Association association) {
+	public boolean targetIsNavigableAndSourceIsComposite(Association association) {
 		final Property target = AssociationServices.INSTANCE.getTarget(association);
-		return isNavigable(target) && isComposite(target);
+		final Property source = AssociationServices.INSTANCE.getSource(association);
+		return isNavigable(target) && isComposite(source);
 	}
 
 	/**
@@ -631,9 +634,10 @@ public class ClassDiagramServices extends AbstractDiagramServices {
 	 *            Association
 	 * @return True if target is navigable and shared
 	 */
-	public boolean targetIsNavigableAndShared(Association association) {
+	public boolean targetIsNavigableAndSourceIsShared(Association association) {
 		final Property target = AssociationServices.INSTANCE.getTarget(association);
-		return isNavigable(target) && isShared(target);
+		final Property source = AssociationServices.INSTANCE.getSource(association);
+		return isNavigable(target) && isShared(source);
 	}
 
 	/**

--- a/plugins/org.obeonetwork.dsl.uml2.properties/src/org/obeonetwork/dsl/uml2/properties/uml/components/AssociationCustomPropertiesEditionComponent.java
+++ b/plugins/org.obeonetwork.dsl.uml2.properties/src/org/obeonetwork/dsl/uml2/properties/uml/components/AssociationCustomPropertiesEditionComponent.java
@@ -59,7 +59,8 @@ public class AssociationCustomPropertiesEditionComponent extends AssociationProp
                 Property property = (Property) event.getNewValue();
                 Association association = property.getAssociation();
                 if (wasOwned) {
-                    ((org.eclipse.uml2.uml.Class) property.getType()).getOwnedAttributes().add(property);
+                	((org.eclipse.uml2.uml.Class)property.getOtherEnd().getType()).getOwnedAttributes()
+					.add(property);
                 } else {
                     association.getOwnedEnds().add(property);
                 }


### PR DESCRIPTION
Integartion de la pull request 771:

Class diagram: Association evolution in UML 2.5
-  Aggregation kind  symbol:
   According to the UML 2.5, the aggregation symbol is now displayed on the opposite end line of the end marked. When a composite or a shared association is created, the target container of the association is the aggregate element.

- Edit end association property: owned attribut
   According to the UML2.5, if the property is not owned by the association, it is owned by the opposite classifier. When the owned attribut is edit from the property view, if the check-box is un-selected, the property is moved under the classifier at the other end of the association.

