### PR TITLE
Fix #756 only first level elements comments visible

### DIFF
--- a/plugins/org.obeonetwork.dsl.uml2.design/src/org/obeonetwork/dsl/uml2/design/api/services/ReusedDescriptionServices.java
+++ b/plugins/org.obeonetwork.dsl.uml2.design/src/org/obeonetwork/dsl/uml2/design/api/services/ReusedDescriptionServices.java
@@ -466,7 +466,8 @@ public class ReusedDescriptionServices extends AbstractDiagramServices {
 			}
 		}
 
-		for (final DDiagramElement elt : diagram.getOwnedDiagramElements()) {
+
+		for (final DDiagramElement elt : diagram.getDiagramElements()) {
 			if (elt.isVisible() && elt.getTarget() instanceof Element
 					&& !((Element)elt.getTarget()).getOwnedComments().isEmpty()) {
 				result.addAll(((Element)elt.getTarget()).getOwnedComments());


### PR DESCRIPTION
In a diagram if the viewpoint comments is actif, only the comments
attached to the elements contained directly in the diagram are displayed.
Other comments are not showned but tools allow to create these comments.