### PR TITLE
Fix #832 Unable to reach the test page from the Developer guide menu

### DIFF
--- a/documentation/_data/pages.yml
+++ b/documentation/_data/pages.yml
@@ -61,7 +61,7 @@
   - title: Build
     file: developer-guide/build
   - title: Test
-    file: developer-guide/build
+    file: developer-guide/test
   - title: Release
     file: developer-guide/release
   - title: Documentation


### PR DESCRIPTION
The *test* section is now available from the **Developer guide** menu.