### PR TITLE
Fix: #855 ctrl-Z for n-ary assocaition

### DIFF
--- a/plugins/org.obeonetwork.dsl.uml2.design/src/org/obeonetwork/dsl/uml2/design/api/services/ClassDiagramServices.java
+++ b/plugins/org.obeonetwork.dsl.uml2.design/src/org/obeonetwork/dsl/uml2/design/api/services/ClassDiagramServices.java
@@ -146,9 +146,8 @@ public class ClassDiagramServices extends AbstractDiagramServices {
 					fixAssociation(association, type);
 				} else { // create new end
 					final Property end = createAssociationEnd(type);
-					association.getOwnedEnds().add(end);
-					association.getMemberEnds().add(end);
 					association.getNavigableOwnedEnds().add(end);
+					association.getOwnedEnds().add(end);
 				}
 			}
 		}


### PR DESCRIPTION
Association end set order is important. If the new end is added first
to the onwnedEnd before to be added to the ownedNavigableEnd the Ctrl-z is
not done.