### PR TITLE
Fix #880 Missing HashSet import in JAVA classes

### DIFF
--- a/plugins/org.eclipse.umlgen.gen.java/src/org/eclipse/umlgen/gen/java/services/ImportServices.java
+++ b/plugins/org.eclipse.umlgen.gen.java/src/org/eclipse/umlgen/gen/java/services/ImportServices.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2014 Obeo and others.
+ * Copyright (c) 2011, 2017 Obeo and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -244,6 +244,13 @@ public class ImportServices {
                 Type type = property.getType();
                 if (type != null && !type.equals(aClassifier)) {
                     importedTypes.add(this.qualifiedName(type, ignoreJavaTypes));
+                }
+                if (property.getUpper() != 1) {
+                    String collectionQualifiedName = this.collectionQualifiedName(aClassifier, property
+                            .isOrdered(), property.isUnique());
+                    if (collectionQualifiedName != null) {
+                        importedTypes.add(collectionQualifiedName);
+                    }
                 }
             }
         }


### PR DESCRIPTION
The collections type (HashSet, ArrayList) were missing in case of
multi-valuated associations.

Change-Id: Iebd77eece062e36ef610c6385dc6b0ae4d4ff90e
Signed-off-by: Axel Richard <axel.richard@obeo.fr>