### PR TITLE
Fix #908 Wrong title location for Device nodes in Deployment diagram

### DIFF
--- a/plugins/org.obeonetwork.dsl.uml2.design/images/boxBlue.svg
+++ b/plugins/org.obeonetwork.dsl.uml2.design/images/boxBlue.svg
@@ -10,13 +10,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="100"
-   height="50"
+   width="98.439003"
+   height="48.284"
    id="svg3149"
    version="1.1"
-   viewBox="0 0 100 50"
+   viewBox="0 0 98.439003 48.284"
    preserveAspectRatio="none"
-   inkscape:version="0.48.3.1 r9886"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="boxBlue.svg">
   <defs
      id="defs3151">
@@ -68,9 +68,9 @@
     <inkscape:perspective
        sodipodi:type="inkscape:persp3d"
        inkscape:vp_x="1775.3948 : 239.1616 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="-405.26591 : 6.1479003 : 1"
-       inkscape:persp3d-origin="903.29724 : 622.66239 : 1"
+       inkscape:vp_y="0 : 999.99999 : 0"
+       inkscape:vp_z="-405.26591 : 6.1479002 : 1"
+       inkscape:persp3d-origin="903.29724 : 622.66238 : 1"
        id="perspective3157" />
   </defs>
   <sodipodi:namedview
@@ -81,15 +81,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="5.6568545"
-     inkscape:cx="42.646154"
+     inkscape:cx="41.231941"
      inkscape:cy="12.700198"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
-     inkscape:window-width="977"
-     inkscape:window-height="751"
-     inkscape:window-x="1519"
-     inkscape:window-y="227"
+     inkscape:window-width="1136"
+     inkscape:window-height="672"
+     inkscape:window-x="223"
+     inkscape:window-y="123"
      inkscape:window-maximized="0" />
   <metadata
      id="metadata3154">
@@ -99,7 +99,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -107,29 +107,29 @@
      inkscape:label="Calque 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(0,-1002.3622)">
+     transform="translate(0,-1004.0782)">
     <rect
-       style="fill:#acbbca;fill-opacity:1;stroke:#274c72;stroke-width:0.16394411;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#acbbca;fill-opacity:1;stroke:#274c72;stroke-width:0.16394411;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect3229-9"
        width="94.852158"
        height="3.5007994"
-       x="-2662.5942"
-       y="2863.0688"
+       x="-2665.5247"
+       y="2865.3975"
        transform="matrix(1,0,0.93030127,0.36679633,0,0)" />
     <rect
-       style="fill:#d0d9e2;fill-opacity:1;stroke:#274c72;stroke-width:0.15211478;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#d0d9e2;fill-opacity:1;stroke:#274c72;stroke-width:0.15211478;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect3229-4"
        width="4.4265585"
        height="46.828499"
-       x="98.980026"
-       y="975.1507"
+       x="98.183014"
+       y="976.23163"
        transform="matrix(0.95864144,0.28461658,0,1,0,0)" />
     <rect
-       style="fill:#fafafa;fill-opacity:1;fill-rule:nonzero;stroke:#274c72;stroke-width:0.14893596;stroke-miterlimit:2;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#fafafa;fill-opacity:1;fill-rule:nonzero;stroke:#274c72;stroke-width:0.14893596;stroke-miterlimit:2;stroke-dasharray:none;stroke-opacity:1"
        id="rect3229"
        width="93.799042"
        height="46.780098"
-       x="0.9840641"
-       y="1003.3452" />
+       x="0.22001542"
+       y="1004.1993" />
   </g>
 </svg>

--- a/plugins/org.obeonetwork.dsl.uml2.design/images/boxGray.svg
+++ b/plugins/org.obeonetwork.dsl.uml2.design/images/boxGray.svg
@@ -10,13 +10,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="100"
-   height="50"
+   width="98.697998"
+   height="48.667999"
    id="svg3149"
    version="1.1"
-   viewBox="0 0 100 50"
+   viewBox="0 0 98.697998 48.667999"
    preserveAspectRatio="none"
-   inkscape:version="0.48.3.1 r9886"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="boxGray.svg">
   <defs
      id="defs3151">
@@ -68,7 +68,7 @@
     <inkscape:perspective
        sodipodi:type="inkscape:persp3d"
        inkscape:vp_x="1775.3948 : 239.1616 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_y="0 : 999.99999 : 0"
        inkscape:vp_z="-405.26591 : 6.1479003 : 1"
        inkscape:persp3d-origin="903.29724 : 622.66239 : 1"
        id="perspective3157" />
@@ -81,15 +81,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="8.0000004"
-     inkscape:cx="52.180269"
+     inkscape:cx="31.18027"
      inkscape:cy="17.24244"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
-     inkscape:window-width="1600"
-     inkscape:window-height="878"
-     inkscape:window-x="-8"
-     inkscape:window-y="172"
+     inkscape:window-width="1680"
+     inkscape:window-height="940"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
      inkscape:window-maximized="1" />
   <metadata
      id="metadata3154">
@@ -99,7 +99,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -107,29 +107,29 @@
      inkscape:label="Calque 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(0,-1002.3622)">
+     transform="translate(0,-1003.6942)">
     <rect
-       style="fill:#bbbbbb;fill-opacity:1;stroke:#888888;stroke-width:0.16443403;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#bbbbbb;fill-opacity:1;stroke:#888888;stroke-width:0.16443403;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect3229-9-1"
        width="95.101509"
        height="3.5125201"
-       x="-2649.2551"
-       y="2850.6113"
+       x="-2651.3938"
+       y="2852.2527"
        transform="matrix(1,0,0.92963451,0.36848293,0,0)" />
     <rect
-       style="fill:#d9d9d9;fill-opacity:1;stroke:#888888;stroke-width:0.15295275;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#d9d9d9;fill-opacity:1;stroke:#888888;stroke-width:0.15295275;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect3229-4-7"
        width="4.4401121"
        height="47.201328"
-       x="99.12326"
-       y="974.83789"
+       x="98.48365"
+       y="975.62561"
        transform="matrix(0.95822757,0.28600685,0,1,0,0)" />
     <rect
-       style="fill:#fafafa;fill-opacity:1;fill-rule:nonzero;stroke:#888888;stroke-width:0.14972408;stroke-miterlimit:2;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#fafafa;fill-opacity:1;fill-rule:nonzero;stroke:#888888;stroke-width:0.14972408;stroke-miterlimit:2;stroke-dasharray:none;stroke-opacity:1"
        id="rect3229-40"
        width="94.045631"
        height="47.152538"
-       x="0.83349055"
-       y="1003.2111" />
+       x="0.22060107"
+       y="1003.8159" />
   </g>
 </svg>

--- a/plugins/org.obeonetwork.dsl.uml2.design/images/boxGreen.svg
+++ b/plugins/org.obeonetwork.dsl.uml2.design/images/boxGreen.svg
@@ -10,13 +10,13 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="100"
-   height="50"
+   width="98.356003"
+   height="48.477001"
    id="svg3149"
    version="1.1"
-   viewBox="0 0 100 50"
+   viewBox="0 0 98.356003 48.477001"
    preserveAspectRatio="none"
-   inkscape:version="0.48.3.1 r9886"
+   inkscape:version="0.91 r13725"
    sodipodi:docname="boxGreen.svg">
   <defs
      id="defs3151">
@@ -81,15 +81,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="7.2407734"
-     inkscape:cx="19.064816"
+     inkscape:cx="45.58132"
      inkscape:cy="16.57247"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      inkscape:window-width="1501"
      inkscape:window-height="1002"
-     inkscape:window-x="1600"
-     inkscape:window-y="0"
+     inkscape:window-x="6"
+     inkscape:window-y="3"
      inkscape:window-maximized="0" />
   <metadata
      id="metadata3154">
@@ -99,7 +99,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -107,29 +107,29 @@
      inkscape:label="Calque 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(0,-1002.3622)">
+     transform="translate(0,-1003.8852)">
     <rect
-       style="fill:#bbc9ad;fill-opacity:1;stroke:#4d8914;stroke-width:0.16385913;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#bbc9ad;fill-opacity:1;stroke:#4d8914;stroke-width:0.16385913;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect3229-9-1"
        width="94.771927"
        height="3.5001316"
-       x="-2650.1497"
-       y="2851.488"
+       x="-2652.6106"
+       y="2853.3853"
        transform="matrix(1,0,0.92969175,0.36833851,0,0)" />
     <rect
-       style="fill:#d9e1d1;fill-opacity:1;stroke:#4d8914;stroke-width:0.15238529;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#d9e1d1;fill-opacity:1;stroke:#4d8914;stroke-width:0.15238529;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect3229-4-7"
        width="4.4245605"
        height="47.016418"
-       x="98.866661"
-       y="975.01929"
+       x="98.139153"
+       y="975.92609"
        transform="matrix(0.95826311,0.28588775,0,1,0,0)" />
     <rect
-       style="fill:#fafafa;fill-opacity:1;fill-rule:nonzero;stroke:#4d8914;stroke-width:0.14917137;stroke-miterlimit:2;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#fafafa;fill-opacity:1;fill-rule:nonzero;stroke:#4d8914;stroke-width:0.14917137;stroke-miterlimit:2;stroke-dasharray:none;stroke-opacity:1"
        id="rect3229-40"
        width="93.719711"
        height="46.967823"
-       x="0.91741753"
-       y="1003.3071" />
+       x="0.22027121"
+       y="1004.0059" />
   </g>
 </svg>


### PR DESCRIPTION
It was due to svg images associated with these mappings. I deleted the
spaces around the shapes, and everything is ok now.

Change-Id: Icafe43bf0fd1c0aea2a16dbb7dc21e81edabd6e1
Signed-off-by: Axel Richard <axel.richard@obeo.fr>