### PR TITLE
Added includeAllDepnedencies to update site creation

### DIFF
--- a/packaging/org.obeonetwork.dsl.uml2.update/pom.xml
+++ b/packaging/org.obeonetwork.dsl.uml2.update/pom.xml
@@ -29,6 +29,30 @@ Contributors:
   <build>
     <plugins>
       <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-p2-repository-plugin</artifactId>
+        <version>0.24.0</version>
+        <executions>
+          <execution>
+            <id>default-assemble-repository</id>
+            <phase>package</phase>
+            <goals>
+              <goal>assemble-repository</goal>
+            </goals>
+            <configuration>
+            	<includeAllDependencies>true</includeAllDependencies>
+            </configuration>
+          </execution>
+          <execution>
+            <id>default-archive-repository</id>
+            <phase>package</phase>
+            <goals>
+              <goal>archive-repository</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <executions>
           <execution>


### PR DESCRIPTION
This will fix issue #1047.  I hope this can be addressed quickly as we are mirroring the update site for the 9.0.0 release and we cannot use it in eclipse.